### PR TITLE
fix: update ClickUp workspace link to stable /home URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
                 <div class="link-category">
                     <h2>📋 Project Management</h2>
                     <div class="link-group">
-                        <a href="https://app.clickup.com/9011178125/home" target="_blank" class="link-card">
+                        <a href="https://app.clickup.com/home" target="_blank" class="link-card">
                             <h3>ClickUp Workspace</h3>
                             <p>Project management & tasks</p>
                         </a>


### PR DESCRIPTION
Replaced the session-specific ClickUp workspace URL with the stable https://app.clickup.com/home link.

This ensures consistent access to the ClickUp workspace for all team members without session-based URL changes.
