### PR TITLE
feat: Add employer web app staging link and company registry section

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,6 +50,10 @@
                             <h3>Staging API</h3>
                             <p>API Documentation & Testing</p>
                         </a>
+                        <a href="https://stage.web.purpose.hr" target="_blank" class="link-card">
+                            <h3>Employer Web App (Staging)</h3>
+                            <p>Current status of the web application for employers</p>
+                        </a>
                         <a href="https://monitor.cheapo.purpose.hr/spaces/g-kobilarov-space/rooms/monitorcheapopurposehr-local/overview#metrics_correlation=false&after=-900&before=0&utc=Europe%2FBerlin&offset=%2B2&timezoneName=Amsterdam%2C%20Berlin%2C%20Bern%2C%20Rome%2C%20Stockholm%2C%20Vienna&modal=&modalTab=&_o=rc6xCsIwEADQf8nsQRJLjrp2F0GcRI5Lc9EhScVeBBH_3S9wc37Le5v5xg_dcxV4cjE7U6V1Or5WlQqWpqXeuwo4Wnv8RdPhBN5sTHJsfcgjeMYMQ4gWxowBEKOkvBV0cTg30cTKxFdpSmWZuVwA_rb4fAE" target="_blank" class="link-card">
                             <h3>Netdata Monitoring</h3>
                             <p>VM monitoring dashboard</p>
@@ -71,6 +75,16 @@
                         <a href="https://www.figma.com/design/yPNLVTts8wA8Qui2cjzXV9/Recruiters-side?node-id=379-51542&t=36Qc8DR7y5VGZYgQ-1" target="_blank" class="link-card">
                             <h3>Employer App Design</h3>
                             <p>Web App UI/UX</p>
+                        </a>
+                    </div>
+                </div>
+
+                <div class="link-category">
+                    <h2>⚖️ Legal</h2>
+                    <div class="link-group">
+                        <a href="https://unternehmensregister.de/de/registerinformationen?areas=all&companyName=Purpose+UG&searchToken=6biEqJHAo4FCSWlNeCNcIAvKeqMEshrGF9vpU0bF_CK_ZetZU66BKCVPHym0I-eWq_XRhXu1PQcI0bnK3_cCyR5bVL3cYpQwhcpLQU-gZ42lzLXgonoGXWZgbei3QrceUad5fS6YsHS0MHHB2ScAAxy8_kRk2sLBSt8hNFcRNRXmRPuV9iQlt78YMtrtXRhYPnDmpWFC&formType=REGISTER_INFORMATION&payload=P4b5DvtqiTXd9aKQNsIsXHi6ZWqNsR7qPjuR2kzrlXEPk4BGvHqUCbGxX8-MhjiIS32mIJ3D-gHQ77zlUljPPVylZd2JqUBpBSh3jNcXlJb2OP11S05y0-DeZYHiMS5edn4-zyQIh4YvFup9juaAyYl54L3RFmhHqiloNsZ2MHsQi1JFY0LQ9a00f8vz7LRNSNEuurZ4X05N" target="_blank" class="link-card">
+                            <h3>Company Registry Information</h3>
+                            <p>Official registry information for Purpose UG (haftungsbeschränkt)</p>
                         </a>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
• Added stage.web.purpose.hr link to Development section for monitoring employer web app status
• Created new Legal section with official German company registry information for Purpose UG

## Test plan
- [x] Verify all links open correctly in new tabs
- [x] Check that new Legal section displays properly with correct styling
- [x] Confirm employer web app staging link works and shows current application status